### PR TITLE
Fix aarch64 cross compile 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            arch: arm64
+            arch: arm64 # for Cross-Compile Support
             name: puzzle_game-aarch64-unknown-linux-gnu.tar.gz
 
           # - target: aarch64-apple-darwin
@@ -50,6 +50,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Install Cross-Compile Support (ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
         uses: cyberjunk/gha-ubuntu-cross@v4
         with:
           arch: arm64


### PR DESCRIPTION
I don't think libx11-dev can be used on Ubuntu(aarch64).
Need this [cross-compile-support-on-ubuntu](https://github.com/marketplace/actions/cross-compile-support-on-ubuntu).